### PR TITLE
Add an empty fragment shader for stencil pass

### DIFF
--- a/shaders/deferred_stencil.frag
+++ b/shaders/deferred_stencil.frag
@@ -1,0 +1,4 @@
+#version 330 core
+ 
+void main(){ // make certain GLs happy by having a fragment stage
+}


### PR DESCRIPTION
Apparently needed to fix GL errors on OSX